### PR TITLE
Setup V2 to be able to install with gomod

### DIFF
--- a/cmd/example.go
+++ b/cmd/example.go
@@ -10,7 +10,7 @@ package main
 import (
 	"fmt"
 
-	timezone "github.com/evanoberholster/timezoneLookup@v2.0.0"
+	timezone "github.com/evanoberholster/timezoneLookup/v2"
 )
 
 func main() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"time"
 
-	timezone "github.com/evanoberholster/timezoneLookup"
+	timezone "github.com/evanoberholster/timezoneLookup/v2"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/evanoberholster/timezoneLookup
+module github.com/evanoberholster/timezoneLookup/v2
 
 go 1.16
 

--- a/import.go
+++ b/import.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/evanoberholster/timezoneLookup/geo"
+	"github.com/evanoberholster/timezoneLookup/v2/geo"
 	"github.com/klauspost/compress/zip"
 )
 

--- a/timezone.go
+++ b/timezone.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/evanoberholster/timezoneLookup/geo"
+	"github.com/evanoberholster/timezoneLookup/v2/geo"
 	"golang.org/x/sys/unix"
 )
 


### PR DESCRIPTION
Should resolve the following error:

```
go get -u github.com/evanoberholster/timezoneLookup@v2.0.0
go: github.com/evanoberholster/timezoneLookup@v2.0.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/evanoberholster/timezoneLookup/v2")
```

Reported here:

https://github.com/evanoberholster/timezoneLookup/issues/7

As per this [doc](https://therootcompany.com/blog/bump-go-package-to-v2/), it would be awesome
if you could please run the following:

```
# remove it
git tag -d v2.0.0
git push origin :v2.0.0

git tag v2.0.0
git push --tags
```