### PR TITLE
Invert iter test in geo/latlng

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 *.db
 *.json
 
-/cmd/timezone.data
-/cmd/timezone
+timezone.data
+timezone

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Download datasource and build timezone database ~50mb
 ./timezone -build
 ```
 
-Test query for San Fransisco, United States (Etc/GMT+8)
+Test query for San Fransisco, United States (America/Los_Angeles)
 ```
 ./timezone -search -lat=37.7749 -lng=-122.4194
 ```

--- a/geo/latlng.go
+++ b/geo/latlng.go
@@ -62,7 +62,7 @@ func (r *rect) searchLatLng(
 	if height == 0 {
 		for i := 0; i < n.count; i++ {
 			if target.intersects(&n.rects[i]) {
-				if !iter(LatLng{n.rects[i].min[0], n.rects[i].min[1]}, LatLng{n.rects[i].max[0], n.rects[i].max[1]}, n.rects[i].data) {
+				if iter(LatLng{n.rects[i].min[0], n.rects[i].min[1]}, LatLng{n.rects[i].max[0], n.rects[i].max[1]}, n.rects[i].data) {
 					return false
 				}
 			}

--- a/timezone_test.go
+++ b/timezone_test.go
@@ -1,0 +1,65 @@
+package timezoneLookup
+
+import (
+	"os"
+	"testing"
+)
+
+var (
+	searchTestCases = map[[2]float64]string{
+		// Examples from https://github.com/ringsaturn/tzf
+		{34.4200, 111.8674}: "Asia/Shanghai",
+		{34.4200, -97.8674}: "America/Chicago",
+		{31.1139, 121.3547}: "Asia/Shanghai",
+		{36.4432, 139.4382}: "Asia/Tokyo",
+		{50.2506, 24.5212}:  "Europe/Kiev",
+		{52.0152, -0.9671}:  "Europe/London",
+		{46.2747, -4.5706}:  "Etc/GMT",
+		{45.0182, 111.9781}: "Asia/Shanghai",
+		{38.3530, -73.7729}: "Etc/GMT+5",
+
+		{37.7749, -122.4194}: "America/Los_Angeles",
+	}
+)
+
+func buildCache() (Timezonecache, error) {
+	var tzc Timezonecache
+	f, err := os.Open("timezone.data")
+	if err != nil {
+		return tzc, err
+	}
+	return tzc, tzc.Load(f)
+}
+
+func TestSearch(t *testing.T) {
+	tzc, err := buildCache()
+	if err != nil {
+		t.Error(err)
+	}
+
+	for point, name := range searchTestCases {
+		result, err := tzc.Search(point[0], point[1])
+		if err != nil {
+			t.Error(err)
+		}
+		if result.Name != name {
+			t.Errorf("Expected: %v, got %v", name, result.Name)
+		}
+	}
+}
+
+func BenchmarkSearch(b *testing.B) {
+	tzc, err := buildCache()
+	if err != nil {
+		b.Error(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for point := range searchTestCases {
+			_, err := tzc.Search(point[0], point[1])
+			if err != nil {
+				b.Error(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
> Test query for San Fransisco, United States (Etc/GMT+8)

Noticed that San Francisco was coming up an hour off in a separate project (and then the above line in the README): it should be `America/Los_Angeles` instead (<https://time.is/San_Francisco>), I think?

Adding a log to <https://github.com/evanoberholster/timezoneLookup/blob/master/timezone.go#L72> showed that the iteration was continuing passed the initial match, so I tried inverting the check which seems like it passes the added tests, but didn't verify further.

Tests require presence of the `timezone.data` file, but I'm assuming you didn't want those checked in (and it seemed questionable to always download and rebuild); a minimal test case could probably be build up by adding the zones in code, but that seemed beyond the scope of this PR.

Feel free to remove the test file or otherwise alter. Thanks!