### PR TITLE
Fixes #15 - alter mmap/munmap to use portable calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 *.db
 *.json
 
-/cmd/timezone.data
+**/timezone.data
 /cmd/timezone

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/evanoberholster/timezoneLookup/v2
 go 1.16
 
 require (
+	github.com/edsrzf/mmap-go v1.1.0
 	github.com/klauspost/compress v1.13.6
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,7 @@
+github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
+github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Use the package "github.com/edsrzf/mmap-go" to perform os independent mmap and munmap calls.  As a result of this change another platform dependent was discovered because of using `pageSize` as an offset.  On Windows, the MapView call requires an offset that is not a multiple of `pageSize`, but is a multiple of the `AllocationGranularity` which is itself a multiple of `pageSize`.  The easiest way to get around this is to drop the idea of using offsets in the mmap and just start at 0.  This means that the total allocated mmap is larger by the size of the offset but that seems to be a small price to pay to keep the code simple and portable.